### PR TITLE
cleaned up eda nb for outbreak data

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,9 +9,11 @@ dependencies:
 - ipykernel
 - matplotlib
 - nbdev
+- nbformat
 - netCDF4
 - numexpr
 - pandas~=2.0
+- plotly
 - pre-commit
 - python~=3.11.0
 - rasterio

--- a/exploration/outbreak_eda.ipynb
+++ b/exploration/outbreak_eda.ipynb
@@ -41,26 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pwd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%cd .."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "outbreaks_df = pd.read_csv(\n",
-    "    \"data/outbreak_data.csv\", parse_dates=[\"start_date\", \"end_date\"]\n",
+    "    \"../data/outbreak_data.csv\", parse_dates=[\"start_date\", \"end_date\"]\n",
     ").assign(\n",
     "    start_month=lambda df: df.start_date.dt.month,\n",
     "    start_year=lambda df: df.start_date.dt.year,\n",
@@ -135,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "district_geometries = gpd.read_file(\"exploration/geolocations.geojson\")\n",
+    "district_geometries = gpd.read_file(\"geolocations.geojson\")\n",
     "district_geometries"
    ]
   },

--- a/exploration/outbreak_eda.ipynb
+++ b/exploration/outbreak_eda.ipynb
@@ -163,15 +163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "yearly_cases_gdf[\"outbreak\"] = 1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "yearly_cases_gdf[\"outbreak\"] = 1\n",
     "yearly_cases_gdf"
    ]
   },

--- a/exploration/outbreak_eda.ipynb
+++ b/exploration/outbreak_eda.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exploratory Data Analysis of the Outbreak Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook we'll explore cholera outbreak data (2010-2019) for sub-Saharan Africa available [here](https://github.com/HopkinsIDD/cholera_outbreaks_ssa/blob/main/reference_data/outbreak_data.csv). Further metadata about this dataset can be found in the repo's [README.md file](https://github.com/HopkinsIDD/cholera_outbreaks_ssa). This dataset is sourced from [Zheng et al. (2022)](https://www.sciencedirect.com/science/article/pii/S1201971222003034), but for the purposes of this work, we'll use this dataset purely as a source of outbreak data. \n",
+    "\n",
+    "Please refer to our `geolocate.ipynb` within this same repo to see the methodology behind the assembly and pre-processing of the boundary files for all district (administrative level 2) outbreak data (see: `geolocations.geojson`). We will join the district boundary data with the outbreak information in the notebook below. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preprocessing of the outbreak dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "import plotly.express as px\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pwd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outbreaks_df = pd.read_csv(\n",
+    "    \"data/outbreak_data.csv\", parse_dates=[\"start_date\", \"end_date\"]\n",
+    ").assign(\n",
+    "    start_month=lambda df: df.start_date.dt.month,\n",
+    "    start_year=lambda df: df.start_date.dt.year,\n",
+    "    # Do we need duration_in_months?  There is already a duration column that\n",
+    "    # represents the duration in weeks.\n",
+    "    duration_in_months=lambda df: np.ceil(\n",
+    "        (df.end_date - df.start_date) / np.timedelta64(1, \"M\")\n",
+    "    ).astype(int),\n",
+    ")\n",
+    "\n",
+    "outbreaks_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outbreaks_df.dtypes.sort_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Expand `location` parts into separate columns\n",
+    "outbreaks_expanded_location_df = (\n",
+    "    outbreaks_df[\"location\"]\n",
+    "    .str.split(\"::\", expand=True)\n",
+    "    .rename(columns={0: \"who_region\", 1: \"ISO3\", 2: \"admin1\", 3: \"admin2\", 4: \"admin3\"})\n",
+    "    .drop(columns=[\"who_region\"])\n",
+    "    .apply(lambda column: column.str.upper().str.removesuffix(\"HEALTHDISTRICT\"))\n",
+    ")\n",
+    "\n",
+    "outbreaks_expanded_location_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outbreaks_admin2_df = (\n",
+    "    pd.concat(\n",
+    "        [\n",
+    "            outbreaks_expanded_location_df.drop(\"admin3\", axis=1),\n",
+    "            outbreaks_df.drop([\"who_region\", \"country\", \"location\"], axis=1),\n",
+    "        ],\n",
+    "        axis=1,\n",
+    "    )\n",
+    "    .query(\"spatial_scale == 'admin2'\")\n",
+    "    .sort_values(by=[\"ISO3\", \"admin1\", \"admin2\"])\n",
+    ")\n",
+    "\n",
+    "outbreaks_admin2_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We've cleaned up the outbreak dataset above. Now we'll import the administrative boundaries for all districts to give each of the district outbreaks a geographic context. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "district_geometries = gpd.read_file(\"exploration/geolocations.geojson\")\n",
+    "district_geometries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sourcery skip: use-fstring-for-concatenation\n",
+    "yearly_cases_gdf = gpd.GeoDataFrame(\n",
+    "    (\n",
+    "        outbreaks_admin2_df.groupby(\n",
+    "            [\n",
+    "                \"start_year\",\n",
+    "                \"ISO3\",\n",
+    "                \"admin1\",\n",
+    "                \"admin2\",\n",
+    "                \"location_period_id\",\n",
+    "            ]\n",
+    "        )[\"total_suspected_cases\"]\n",
+    "        .sum()\n",
+    "        .reset_index()\n",
+    "    )\n",
+    "    .merge(district_geometries, on=\"location_period_id\")\n",
+    "    .assign(location=lambda gdf: gdf.admin2 + \", \" + gdf.admin1 + \", \" + gdf.ISO3)\n",
+    "    .set_index(\"location_period_id\")\n",
+    ")\n",
+    "\n",
+    "yearly_cases_gdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will add a new column `outbreak` to represent presence of an outbreak in the district (outbreak = 1). This will be used to provide sums or counts of outbreaks and will later be used when we develop a machine learning model and need outbreak absence data points (outbreak = 0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yearly_cases_gdf[\"outbreak\"] = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yearly_cases_gdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Total number of georeferenced outbreaks within the pre-processed dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(yearly_cases_gdf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exploratory data analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we will start exploring those counties that repeatedly see cholera outbreaks. We'll group the district data by both start year and country code. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repeated_outbreaks = yearly_cases_gdf.groupby([\"start_year\", \"ISO3\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repeat_outbreak_bar = px.bar(\n",
+    "    yearly_cases_gdf,\n",
+    "    x=\"ISO3\",\n",
+    "    y=\"outbreak\",\n",
+    "    color=\"start_year\",\n",
+    ")\n",
+    "\n",
+    "repeat_outbreak_bar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mapping Cholera outbreaks from 2010-2019 at the district level\n",
+    "Below, we use `plotly` to map cholera outbreaks over time. This is two get a better sense, geographically, of where repeated outbreaks are occuring and to visualize any spatial autocorrelation between them (i.e., are areas that reapetedly experience outbreaks in closer proximity to each other?)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yearly_snapshot = px.choropleth(\n",
+    "    yearly_cases_gdf,\n",
+    "    locations=yearly_cases_gdf.index,\n",
+    "    geojson=yearly_cases_gdf.geometry,\n",
+    "    color=\"total_suspected_cases\",\n",
+    "    hover_name=\"location\",\n",
+    "    color_continuous_scale=px.colors.sequential.Plasma,\n",
+    "    animation_frame=\"start_year\",\n",
+    "    animation_group=\"location\",\n",
+    "    range_color=[0, 100000],\n",
+    ")\n",
+    "\n",
+    "yearly_snapshot.update_geos(scope=\"africa\")\n",
+    "yearly_snapshot.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geo-ds-cholera",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/exploration/outbreak_eda.ipynb
+++ b/exploration/outbreak_eda.ipynb
@@ -235,7 +235,7 @@
    "metadata": {},
    "source": [
     "## Mapping Cholera outbreaks from 2010-2019 at the district level\n",
-    "Below, we use `plotly` to map cholera outbreaks over time. This is two get a better sense, geographically, of where repeated outbreaks are occuring and to visualize any spatial autocorrelation between them (i.e., are areas that reapetedly experience outbreaks in closer proximity to each other?)"
+    "Below, we use `plotly` to map cholera outbreaks over time. This is to get a better sense, geographically, of where repeated outbreaks are occurring and to visualize any spatial autocorrelation between them (i.e., are areas that repeatedly experience outbreaks in closer proximity to each other?)"
    ]
   },
   {


### PR DESCRIPTION
This PR represents a consolidated and cleaned up version of the outbreak exploratory data analysis that was performed across all of our data exploration branches. 

It reads in the `geojson` file of the admin 2 (district) geometries that were produced in the `geolocation.ipynb`. 

It provides the a graphic and mapped visualization of the spatial and temporal distribution of outbreaks within the dataset. 